### PR TITLE
update browser-pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bundle-collapser": "bin/cmd.js"
   },
   "dependencies": {
-    "browser-pack": "^5.0.1",
+    "browser-pack": "^6.0.2",
     "browser-unpack": "^1.1.0",
     "concat-stream": "^1.5.0",
     "falafel": "^2.1.0",


### PR DESCRIPTION
allows npm to dedupe some dependencies when installing browserify and
bundle-collapser side by side.